### PR TITLE
Adding folder clearing function to staNMF.py, adjusting staNMF.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,14 @@ drosophila spatial expression data between K=15 and K=30; Generates
 sample factorizations, calculates instability index, and plots instability
 against K
 
+================
+staNMF_driver.py
+================
+Driver script to run staNMF in parallel; can be called from the command line
+using:
+python staNMF_driver.py <k1> <k2> <reps1> <reps2> <folder> <filename> <function>
+(See docstring for more specific instructions) 
+
 ============================
 data/WuExampleExpression.csv
 ============================

--- a/staNMF/staNMF.py
+++ b/staNMF/staNMF.py
@@ -64,12 +64,12 @@ class staNMF:
 
     :param: seed (int, optional with default 123): sets numpy random seed
 
-    :param: replicates(int or list of ints of length 2, optional with default
+    :param: replicates(int or tuple of ints of length 2, optional with default
     int 100):
     Specifies which/ how many bootstrapped repetitions to be performed on each
     value of K, for use in stability analysis; if a list of length 2 is given,
     self.replicates is set to a list of ints between the first and second
-    elements of this list. If it is set to an integer, self.replicates is set
+    elements of this tuple. If it is set to an integer, self.replicates is set
     to a list of ints between 0 and the given integer
 
     Number of bootstrapped
@@ -100,9 +100,8 @@ class staNMF:
         self.parallel = parallel
         if isinstance(replicates, int):
             self.replicates = range(replicates)
-        elif isinstance(replicates, list):
+        elif isinstance(replicates, tuple) and len(replicates):
             self.replicates = range(replicates[0], replicates[1])
-
         self.X = []
         if filename == 'example':
             self.fn = os.path.join("data", "WuExampleExpression.csv")
@@ -396,11 +395,12 @@ class staNMF:
                     outputfile = open(str(path + "instability.csv"), "w")
                     outputfile.write("\n" + str(k) + "," + str(
                                         self.instabilitydict[k]))
+                    output.close()
         if not self.parallel:
             outputfile = open("instability.csv", "w")
+            outputwriter = csv.writer(outputfile)
             for i in sorted(self.instabilitydict):
-                outputfile.write(str(i) + "," +
-                                 str(self.instabilitydict[i]) + "\n")
+                outputwriter.writerow([str(i)], [str(self.instabilitydict[i])])
 
     def get_instability(self):
         '''
@@ -446,8 +446,8 @@ class staNMF:
 
         if self.parallel:
             for K in range(x1, x2+1):
-                kpath = str("./staNMFDicts" + str(self.folderID) + "/K=" +
-                            str(K)+"/instability.csv")
+                kpath = "./staNMFDicts{}/K={}/instability.csv".format(
+                                                      self.folderID, K)
                 df = pd.read_csv(kpath)
                 kArray.append(int(df.columns[0]))
                 self.instabilityarray.append(float(df.columns[1]))
@@ -484,6 +484,5 @@ class staNMF:
         each K you wish to delete.
         '''
         for K in k_list:
-            path = str("./staNMFDicts" + str(self.folderID) + "/K=" +
-                       str(K)+"/")
+            path = "./staNMFDicts{}/K={}/".format(self.folderID, K)
             shutil.rmtree(path)

--- a/staNMF/staNMF.py
+++ b/staNMF/staNMF.py
@@ -394,9 +394,10 @@ class staNMF:
 
                 if self.parallel:
                     outputfile = open(str(path + "instability.csv"), "w")
-                    outputfile.write("\n{},{}".format(
-                            k, self.instabilitydict[k]))
-                    output.close()
+                    outputwriter = csv.writer(outputfile)
+                    outputwriter.writerow(k, self.instabilitydict[k])
+                    outputfile.close()
+
         if not self.parallel:
             outputfile = open("instability.csv", "w")
             outputwriter = csv.writer(outputfile)

--- a/staNMF/staNMF.py
+++ b/staNMF/staNMF.py
@@ -393,14 +393,14 @@ class staNMF:
 
                 if self.parallel:
                     outputfile = open(str(path + "instability.csv"), "w")
-                    outputfile.write("\n" + str(k) + "," + str(
-                                        self.instabilitydict[k]))
+                    outputfile.write("\n{},{}".format(
+                            k, self.instabilitydict[k]))
                     output.close()
         if not self.parallel:
             outputfile = open("instability.csv", "w")
             outputwriter = csv.writer(outputfile)
             for i in sorted(self.instabilitydict):
-                outputwriter.writerow([str(i)], [str(self.instabilitydict[i])])
+                outputwriter.writerow([i], [self.instabilitydict[i]])
 
     def get_instability(self):
         '''

--- a/staNMF/staNMF.py
+++ b/staNMF/staNMF.py
@@ -395,14 +395,14 @@ class staNMF:
                 if self.parallel:
                     outputfile = open(str(path + "instability.csv"), "w")
                     outputwriter = csv.writer(outputfile)
-                    outputwriter.writerow(k, self.instabilitydict[k])
+                    outputwriter.writerow([k, self.instabilitydict[k]])
                     outputfile.close()
 
         if not self.parallel:
             outputfile = open("instability.csv", "w")
             outputwriter = csv.writer(outputfile)
             for i in sorted(self.instabilitydict):
-                outputwriter.writerow([i], [self.instabilitydict[i]])
+                outputwriter.writerow([i, self.instabilitydict[i]])
 
     def get_instability(self):
         '''

--- a/staNMF/staNMF.py
+++ b/staNMF/staNMF.py
@@ -100,7 +100,8 @@ class staNMF:
         self.parallel = parallel
         if isinstance(replicates, int):
             self.replicates = range(replicates)
-        elif isinstance(replicates, tuple) and len(replicates):
+        elif isinstance(replicates, tuple):
+            start, stop = replicates
             self.replicates = range(replicates[0], replicates[1])
         self.X = []
         if filename == 'example':

--- a/staNMF/staNMF_driver.py
+++ b/staNMF/staNMF_driver.py
@@ -1,0 +1,66 @@
+import staNMF
+import sys
+import argparse
+'''
+staNMF Driver Script
+
+Function:
+This script is not required, but offers one way to use the three primary user
+functions of staNMF in parallel. It can be called from the command or from a
+shell script using:
+
+$ python staNMF_driver.py <k1> <k2> <reps1> <reps2> <folder> <filename> <function>
+
+:param: k1 (int) - lower bound(inclusive) for K calculations for this call
+
+:param: k2 (int) - upper bound(inclusive) for K calculations in this call; note
+that if you are breaking one K's calculation into multiple calls, k1 and k2 can
+be the same integer
+
+:param: reps1 (int) - lower bound(inclusive) for the NMF factorizations
+generated in this call
+
+:param: reps2 (int) -upper bound (not inclusive) for the NMF factorizations
+generated in this call --NOTE: if you are calling instability or plot,
+range(reps1, reps2) should include all the existing factorizations you wish to
+input into the instability or plot function performed in this call
+
+:param: folder (str) - folder ID for NMF factorizations that are either to be
+generated(by runNMF) or are to be used by instabilty/plot
+
+:param: filename (str) - .csv file containing the full dataset
+
+;param: function (str) - the staNMF function to be run in this call; cannot be
+more than one and must be 'runNMF', 'instability', or 'plot'
+
+'''
+parser = argparse.ArgumentParser()
+
+parser.add_argument("k1", type=int)
+parser.add_argument("k2", type=int)
+parser.add_argument("reps1", type=int)
+parser.add_argument("reps2", type=int)
+parser.add_argument("folder", type=str)
+parser.add_argument("filename", type=str)
+parser.add_argument("function", choices=['runNMF', 'instability', 'plot'])
+args = parser.parse_args()
+
+if args.function == 'runNMF':
+    staNMFobj = staNMF.staNMF(filename=args.filename, K1=args.k1, K2=args.k2,
+                              replicates=(args.reps1, args.reps2),
+                              folderID=args.folder, parallel=True)
+    staNMFobj.runNMF()
+
+elif args.function == 'instability':
+    staNMFobj = staNMF.staNMF(filename=args.filename, K1=args.k1,
+                              K2=args.k2, replicates=(args.reps1, args.reps2),
+                              folderID=args.folder, NMF_finished=True,
+                              parallel=True)
+    staNMFobj.instability()
+
+elif args.function == 'plot':
+    staNMFobj = staNMF.staNMF(filename="PanCanMatrix.csv", K1=k1, K2=k2,
+                              replicates1=reps1, replicates2=reps2,
+                              folderID=folder, NMF_finished=True,
+                              parallel=True)
+    staNMFobj.plot(done=True)

--- a/staNMF/staNMF_driver.py
+++ b/staNMF/staNMF_driver.py
@@ -1,7 +1,6 @@
-import staNMF
-import sys
-import argparse
 '''
+Amy Campbell
+
 staNMF Driver Script
 
 Function:
@@ -34,6 +33,10 @@ generated(by runNMF) or are to be used by instabilty/plot
 more than one and must be 'runNMF', 'instability', or 'plot'
 
 '''
+import staNMF
+import sys
+import argparse
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument("k1", type=int)
@@ -59,8 +62,8 @@ elif args.function == 'instability':
     staNMFobj.instability()
 
 elif args.function == 'plot':
-    staNMFobj = staNMF.staNMF(filename="PanCanMatrix.csv", K1=k1, K2=k2,
-                              replicates1=reps1, replicates2=reps2,
-                              folderID=folder, NMF_finished=True,
+    staNMFobj = staNMF.staNMF(filename=args.filename, K1=args.k1, K2=args.k2,
+                              replicates1=args.reps1, replicates2=args.reps2,
+                              folderID=args.folder, NMF_finished=True,
                               parallel=True)
     staNMFobj.plot(done=True)


### PR DESCRIPTION
In this pull request (to be followed with one with cluster driving scripts), I add the ClearDirectory() method to fulfill the enhancement suggested by @gwaygenomics, and update staNMF.py to allow it to be more easily parallelized. I do so with the following changes:
- The constructor now allows the user to input either an integer or a range of integers(in the form of a python list) for the **replicates** variable. This way, the user can either calculate all factorizations of a given K at once(ex: replicates=100 would output factorization files 1 through 99), or break them into separate calls (ex: replicates=[0,50] in one call, replicates=[50,100] in another). 
- The instability() function now outputs an instability.csv file for each separate K if the user sets instability(parallel=True), so that instability can be calculated for each K independently, and then be used by the same call to plot(). 
- The plot() function can now either plot instability based on the staNMF object's existing self.instabilitydict, or can collect instability measures from each K folder and plot those. 
- The call to import matplotlib specifies the 'Agg' backend in order to be able to save plots on remote machines. I do know that including the matplotlib.use() call in the section of imported files conflicts with pep8 style, but I do want to import plt as a shortcut for matplotlib.pyplot (and have to do it after specifying the backend). Any ideas for workarounds for this? 
